### PR TITLE
refactor: keep formatter properties on clone

### DIFF
--- a/src/BetterNumberFormatter.php
+++ b/src/BetterNumberFormatter.php
@@ -40,11 +40,28 @@ final class BetterNumberFormatter
 
     private NumberFormatter $formatter;
 
-    private function __construct(string $locale, int $style)
-    {
+    private function __construct(
+        string $locale,
+        int $style,
+        array $attributes = [],
+        array $textAttributes = [],
+        array $symbols = []
+    ) {
         $this->locale    = $locale;
         $this->style     = $style;
         $this->formatter = new NumberFormatter($locale, $style);
+
+        foreach ($attributes as $attribute => $value) {
+            $this->setAttribute($attribute, $value);
+        }
+
+        foreach ($textAttributes as $attribute => $value) {
+            $this->setTextAttribute($attribute, $value);
+        }
+
+        foreach ($symbols as $symbol => $value) {
+            $this->setSymbol($symbol, $value);
+        }
     }
 
     public static function new(string $locale = 'en_US', int $style = NumberFormatter::DECIMAL): self
@@ -54,11 +71,23 @@ final class BetterNumberFormatter
 
     public function withLocale(string $locale): self
     {
-        return new static($locale, $this->style);
+        return new static(
+            $locale,
+            $this->style,
+            $this->attributes,
+            $this->textAttributes,
+            $this->symbols
+        );
     }
 
     public function withStyle(int $style): self
     {
-        return new static($this->locale, $style);
+        return new static(
+            $this->locale,
+            $style,
+            $this->attributes,
+            $this->textAttributes,
+            $this->symbols
+        );
     }
 }

--- a/src/Concerns/HasAttributes.php
+++ b/src/Concerns/HasAttributes.php
@@ -17,129 +17,103 @@ use NumberFormatter;
 
 trait HasAttributes
 {
+    private array $attributes = [];
+
     public function withParseIntOnly(int | float $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::PARSE_INT_ONLY, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::PARSE_INT_ONLY, $value);
     }
 
     public function withGroupingUsed(int | float $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::GROUPING_USED, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::GROUPING_USED, $value);
     }
 
     public function withDecimalAlwaysShown(int | float $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::DECIMAL_ALWAYS_SHOWN, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::DECIMAL_ALWAYS_SHOWN, $value);
     }
 
     public function withMaxIntegerDigits(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::MAX_INTEGER_DIGITS, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::MAX_INTEGER_DIGITS, $value);
     }
 
     public function withMinIntegerDigits(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::MIN_INTEGER_DIGITS, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::MIN_INTEGER_DIGITS, $value);
     }
 
     public function withIntegerDigits(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::INTEGER_DIGITS, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::INTEGER_DIGITS, $value);
     }
 
     public function withMaxFractionDigits(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $value);
     }
 
     public function withMinFractionDigits(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $value);
     }
 
     public function withFractionDigits(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::FRACTION_DIGITS, $value);
     }
 
     public function withMultiplier(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::MULTIPLIER, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::MULTIPLIER, $value);
     }
 
     public function withGroupingSize(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::GROUPING_SIZE, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::GROUPING_SIZE, $value);
     }
 
     // @TODO
     public function withRoundingIncrement(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::ROUNDING_INCREMENT, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::ROUNDING_INCREMENT, $value);
     }
 
     public function withFormatWidth(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::FORMAT_WIDTH, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::FORMAT_WIDTH, $value);
     }
 
     public function withSecondaryGroupingSize(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::SECONDARY_GROUPING_SIZE, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::SECONDARY_GROUPING_SIZE, $value);
     }
 
     public function withSignificantDigitsUsed(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::SIGNIFICANT_DIGITS_USED, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::SIGNIFICANT_DIGITS_USED, $value);
     }
 
     public function withMinSignificantDigits(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::MIN_SIGNIFICANT_DIGITS, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::MIN_SIGNIFICANT_DIGITS, $value);
     }
 
     public function withMaxSignificantDigits(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::MAX_SIGNIFICANT_DIGITS, $value);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::MAX_SIGNIFICANT_DIGITS, $value);
     }
 
     public function withLenientParse(int $value): self
     {
-        $this->formatter->setAttribute(NumberFormatter::LENIENT_PARSE, $value);
+        return $this->setAttribute(NumberFormatter::LENIENT_PARSE, $value);
+    }
+
+    private function setAttribute(int $attribute, int $value): self
+    {
+        $this->formatter->setAttribute($attribute, $value);
+        $this->attributes[$attribute] = $value;
 
         return $this;
     }

--- a/src/Concerns/HasFormatters.php
+++ b/src/Concerns/HasFormatters.php
@@ -73,9 +73,25 @@ trait HasFormatters
         return $this->withStyle(NumberFormatter::SPELLOUT)->format($value);
     }
 
-    private function format(int | float $value): string
+    public function format(int | float $value): string
     {
         $value = $this->formatter->format($value);
+
+        if ($value === false) {
+            throw new RuntimeException('Failed to format the given value.');
+        }
+
+        return $value;
+    }
+
+    public function formatCurrency(int | float $value, ?string $currency = null): string
+    {
+        $value = $this->withStyle(NumberFormatter::CURRENCY)
+            ->formatter
+            ->formatCurrency(
+                $value,
+                $currency ?? $this->getTextAttribute(NumberFormatter::CURRENCY_CODE)
+            );
 
         if ($value === false) {
             throw new RuntimeException('Failed to format the given value.');

--- a/src/Concerns/HasPadding.php
+++ b/src/Concerns/HasPadding.php
@@ -19,29 +19,21 @@ trait HasPadding
 {
     public function withPaddingAfterPrefix(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::PADDING_POSITION, NumberFormatter::PAD_AFTER_PREFIX);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::PADDING_POSITION, NumberFormatter::PAD_AFTER_PREFIX);
     }
 
     public function withPaddingAfterSuffix(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::PADDING_POSITION, NumberFormatter::PAD_AFTER_SUFFIX);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::PADDING_POSITION, NumberFormatter::PAD_AFTER_SUFFIX);
     }
 
     public function withPaddingBeforePrefix(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::PADDING_POSITION, NumberFormatter::PAD_BEFORE_PREFIX);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::PADDING_POSITION, NumberFormatter::PAD_BEFORE_PREFIX);
     }
 
     public function withPaddingBeforeSuffix(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::PADDING_POSITION, NumberFormatter::PAD_BEFORE_SUFFIX);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::PADDING_POSITION, NumberFormatter::PAD_BEFORE_SUFFIX);
     }
 }

--- a/src/Concerns/HasRounding.php
+++ b/src/Concerns/HasRounding.php
@@ -19,50 +19,36 @@ trait HasRounding
 {
     public function withCeilingRounding(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_CEILING);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_CEILING);
     }
 
     public function withDownRounding(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_DOWN);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_DOWN);
     }
 
     public function withFloorRounding(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_FLOOR);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_FLOOR);
     }
 
     public function withHalfDownRounding(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_HALFDOWN);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_HALFDOWN);
     }
 
     public function withHalfEvenRounding(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_HALFEVEN);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_HALFEVEN);
     }
 
     public function withHalfUpRounding(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_HALFUP);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_HALFUP);
     }
 
     public function withUpRounding(): self
     {
-        $this->formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_UP);
-
-        return $this;
+        return $this->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_UP);
     }
 }

--- a/src/Concerns/HasSymbol.php
+++ b/src/Concerns/HasSymbol.php
@@ -17,128 +17,102 @@ use NumberFormatter;
 
 trait HasSymbol
 {
+    private array $symbols = [];
+
     public function withDecimalSeparatorSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL, $value);
     }
 
     public function withGroupingSeparatorSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::GROUPING_SEPARATOR_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::GROUPING_SEPARATOR_SYMBOL, $value);
     }
 
     public function withPatternSeparatorSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::PATTERN_SEPARATOR_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::PATTERN_SEPARATOR_SYMBOL, $value);
     }
 
     public function withPercentSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::PERCENT_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::PERCENT_SYMBOL, $value);
     }
 
     public function withZeroDigitSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::ZERO_DIGIT_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::ZERO_DIGIT_SYMBOL, $value);
     }
 
     public function withDigitSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::DIGIT_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::DIGIT_SYMBOL, $value);
     }
 
     public function withMinusSignSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::MINUS_SIGN_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::MINUS_SIGN_SYMBOL, $value);
     }
 
     public function withPlusSignSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::PLUS_SIGN_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::PLUS_SIGN_SYMBOL, $value);
     }
 
     public function withCurrencySymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::CURRENCY_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::CURRENCY_SYMBOL, $value);
     }
 
     public function withIntlCurrencySymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::INTL_CURRENCY_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::INTL_CURRENCY_SYMBOL, $value);
     }
 
     public function withMonetarySeparatorSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::MONETARY_SEPARATOR_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::MONETARY_SEPARATOR_SYMBOL, $value);
     }
 
     public function withExponentialSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::EXPONENTIAL_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::EXPONENTIAL_SYMBOL, $value);
     }
 
     public function withPermillSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::PERMILL_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::PERMILL_SYMBOL, $value);
     }
 
     public function withPadEscapeSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::PAD_ESCAPE_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::PAD_ESCAPE_SYMBOL, $value);
     }
 
     public function withInfinitySymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::INFINITY_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::INFINITY_SYMBOL, $value);
     }
 
     public function withNanSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::NAN_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::NAN_SYMBOL, $value);
     }
 
     public function withSignificantDigitSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::SIGNIFICANT_DIGIT_SYMBOL, $value);
-
-        return $this;
+        return $this->setSymbol(NumberFormatter::SIGNIFICANT_DIGIT_SYMBOL, $value);
     }
 
     public function withMonetaryGroupingSeparatorSymbol(string $value): self
     {
-        $this->formatter->setSymbol(NumberFormatter::MONETARY_GROUPING_SEPARATOR_SYMBOL, $value);
+        return $this->setSymbol(NumberFormatter::MONETARY_GROUPING_SEPARATOR_SYMBOL, $value);
+    }
+
+    private function setSymbol(int $symbol, string $value): self
+    {
+        $this->formatter->setSymbol($symbol, $value);
+        $this->symbols[$symbol] = $value;
 
         return $this;
     }

--- a/src/Concerns/HasTextAttributes.php
+++ b/src/Concerns/HasTextAttributes.php
@@ -17,58 +17,52 @@ use NumberFormatter;
 
 trait HasTextAttributes
 {
+    private array $textAttributes = [];
+
     public function withPositivePrefix(string $value): self
     {
-        $this->formatter->setTextAttribute(NumberFormatter::POSITIVE_PREFIX, $value);
-
-        return $this;
+        return $this->setTextAttribute(NumberFormatter::POSITIVE_PREFIX, $value);
     }
 
     public function withPositiveSuffix(string $value): self
     {
-        $this->formatter->setTextAttribute(NumberFormatter::POSITIVE_SUFFIX, $value);
-
-        return $this;
+        return $this->setTextAttribute(NumberFormatter::POSITIVE_SUFFIX, $value);
     }
 
     public function withNegativePrefix(string $value): self
     {
-        $this->formatter->setTextAttribute(NumberFormatter::NEGATIVE_PREFIX, $value);
-
-        return $this;
+        return $this->setTextAttribute(NumberFormatter::NEGATIVE_PREFIX, $value);
     }
 
     public function withNegativeSuffix(string $value): self
     {
-        $this->formatter->setTextAttribute(NumberFormatter::NEGATIVE_SUFFIX, $value);
-
-        return $this;
+        return $this->setTextAttribute(NumberFormatter::NEGATIVE_SUFFIX, $value);
     }
 
     public function withPaddingCharacter(string $value): self
     {
-        $this->formatter->setTextAttribute(NumberFormatter::PADDING_CHARACTER, $value);
-
-        return $this;
+        return $this->setTextAttribute(NumberFormatter::PADDING_CHARACTER, $value);
     }
 
     public function withCurrencyCode(string $value): self
     {
-        $this->formatter->setTextAttribute(NumberFormatter::CURRENCY_CODE, $value);
-
-        return $this;
+        return $this->setTextAttribute(NumberFormatter::CURRENCY_CODE, $value);
     }
 
     public function withDefaultRuleset(string $value): self
     {
-        $this->formatter->setTextAttribute(NumberFormatter::DEFAULT_RULESET, $value);
-
-        return $this;
+        return $this->setTextAttribute(NumberFormatter::DEFAULT_RULESET, $value);
     }
 
     public function withPublicRulesets(string $value): self
     {
-        $this->formatter->setTextAttribute(NumberFormatter::PUBLIC_RULESETS, $value);
+        return $this->setTextAttribute(NumberFormatter::PUBLIC_RULESETS, $value);
+    }
+
+    private function setTextAttribute(int $attribute, string $value): self
+    {
+        $this->formatter->setTextAttribute($attribute, $value);
+        $this->textAttributes[$attribute] = $value;
 
         return $this;
     }


### PR DESCRIPTION
Attributes and Symbols which are applied to the formatter get cleared when calling `withLocale` or `withStyle`. This PR re-applies those to the formatter when it's created

It also makes the `format` method public and adds `formatCurrency`